### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ https://www.youtube.com/watch?v=neHvuyEPM8Q&list=PLLUFZCmqicc-ESKvg3XZE-7yX5o_0P
 ###For Email
 
 ####Prerequisites: For running any mail services
+
+(Option - 1 - Probably will not work)
 1. Turn off 2-factor authentication
 2. Allow less secure option shoud be True
 3. IMAP should be enabled
+
+(Option - 2 -Google has discontinued usage of enabling/disabling less secure option. So to integrate 3rd party app and to allow sending mails use below mechanism to authenticate)
+1. Turn on 2-factor authentication.
+2. Generate App password. (This password is different than the Gmail account password).
+3. Use this App password in your camunda spring-boot mailing-config properties.
+(Refer link for generating App password : https://www.youtube.com/watch?v=hXiPshHn9Pw)
 
 
 ####FYI:


### PR DESCRIPTION
Google has discontinued usage of enabling/disabling less secure option. So, using gmail account password in config would not work. Updated readme file after testing the new way of authentication.